### PR TITLE
Add checker size controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,6 +80,8 @@ const App = () => {
           setBlueTrailLength={setBlueTrailLength}
           mainSphereRotation={mainSphereRotation}
           setMainSphereRotation={setMainSphereRotation}
+          checkerSize={checkerSize}
+          setCheckerSize={setCheckerSize}
         />
       )}
 

--- a/src/ParameterControls.jsx
+++ b/src/ParameterControls.jsx
@@ -15,6 +15,8 @@ const ParameterControls = ({
   setBlueTrailLength,
   mainSphereRotation,
   setMainSphereRotation,
+  checkerSize,
+  setCheckerSize,
 }) => (
   <div className="mb-4 p-2 bg-gray-100 rounded-lg">
     <div className="flex flex-wrap items-center gap-2">
@@ -209,6 +211,36 @@ const ParameterControls = ({
             <button
               className="w-5 h-5 bg-gray-200 rounded-r flex items-center justify-center hover:bg-gray-300 text-xs"
               onClick={() => setMainSphereRotation(mainSphereRotation + 0.001)}
+            >
+              +
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1 p-1 bg-gray-50 border border-gray-200 rounded">
+        <span className="text-xs font-medium mr-1">Checker:</span>
+        <div className="flex items-center">
+          <span className="text-xs">Size</span>
+          <div className="flex items-center ml-1">
+            <button
+              className="w-5 h-5 bg-gray-200 rounded-l flex items-center justify-center hover:bg-gray-300 text-xs"
+              onClick={() => setCheckerSize(Math.max(1, checkerSize - 1))}
+            >
+              -
+            </button>
+            <input
+              type="number"
+              min="1"
+              max="256"
+              step="1"
+              value={checkerSize}
+              onChange={(e) => setCheckerSize(parseInt(e.target.value, 10))}
+              className="w-12 h-5 text-xs text-center border-y outline-none"
+            />
+            <button
+              className="w-5 h-5 bg-gray-200 rounded-r flex items-center justify-center hover:bg-gray-300 text-xs"
+              onClick={() => setCheckerSize(checkerSize + 1)}
             >
               +
             </button>

--- a/src/ThreeDScene.jsx
+++ b/src/ThreeDScene.jsx
@@ -12,6 +12,7 @@ const ThreeDScene = ({ params }) => {
     greenTrailLength = 100,
     blueTrailLength = 100,
     mainSphereRotation = 0.005,
+    checkerSize = 64,
     onTriangleAreaUpdate = () => {},
   } = params || {};
 
@@ -78,7 +79,7 @@ const ThreeDScene = ({ params }) => {
 
     const size = 512;
     const data = new Uint8Array(size * size * 4);
-    const squareSize = 32;
+    const squareSize = checkerSize;
 
     for (let y = 0; y < size; y++) {
       for (let x = 0; x < size; x++) {


### PR DESCRIPTION
## Summary
- expose checkerboard square size in the controls
- pass `checkerSize` to 3D scene
- generate texture squares based on the provided size

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68420215f8948328ab352738d7b329a4