### PR TITLE
Make AreaChart width dynamic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,6 @@ const App = () => {
   const [blueTrailLength, setBlueTrailLength] = useState(50);
 
   const [mainSphereRotation, setMainSphereRotation] = useState(0.005);
-  const [checkerSize, setCheckerSize] = useState(64);
   const [showControls, setShowControls] = useState(true);
   const [triangleArea, setTriangleArea] = useState(0);
 
@@ -37,7 +36,6 @@ const App = () => {
     greenTrailLength,
     blueTrailLength,
     mainSphereRotation,
-    checkerSize,
     onTriangleAreaUpdate: setTriangleArea,
   };
 

--- a/src/AreaChart.jsx
+++ b/src/AreaChart.jsx
@@ -1,13 +1,34 @@
-import React from 'react';
+import React, { useState, useRef, useLayoutEffect } from 'react';
 
-const AreaChart = ({ data }) => {
-  const width = 1600;
+const AreaChart = ({ data, width: propWidth }) => {
+  const containerRef = useRef(null);
+  const [computedWidth, setComputedWidth] = useState(propWidth || 0);
   const height = 128;
   const padding = 2;
 
-  if (!data || data.length < 2) {
+  useLayoutEffect(() => {
+    if (propWidth) {
+      setComputedWidth(propWidth);
+      return;
+    }
+
+    const updateWidth = () => {
+      if (containerRef.current) {
+        setComputedWidth(containerRef.current.clientWidth);
+      }
+    };
+
+    updateWidth();
+    window.addEventListener('resize', updateWidth);
+    return () => window.removeEventListener('resize', updateWidth);
+  }, [propWidth]);
+
+  if (!data || data.length < 2 || computedWidth === 0) {
     return (
-      <div className="w-32 h-8 ml-2 bg-gray-100 rounded flex items-center justify-center text-xs text-gray-400">
+      <div
+        ref={containerRef}
+        className="w-full h-8 ml-2 bg-gray-100 rounded flex items-center justify-center text-xs text-gray-400"
+      >
         Collecting data...
       </div>
     );
@@ -19,15 +40,20 @@ const AreaChart = ({ data }) => {
 
   const points = data
     .map((value, index) => {
-      const x = padding + (index / (data.length - 1)) * (width - 2 * padding);
+      const x =
+        padding + (index / (data.length - 1)) * (computedWidth - 2 * padding);
       const y = height - padding - ((value - minValue) / range) * (height - 2 * padding);
       return `${x},${y}`;
     })
     .join(' ');
 
   return (
-    <div className="ml-2 relative" title={`Min: ${minValue.toFixed(2)}, Max: ${maxValue.toFixed(2)}`}>
-      <svg width={width} height={height} className="border border-gray-200 rounded bg-gray-100">
+    <div
+      ref={containerRef}
+      className="ml-2 relative"
+      title={`Min: ${minValue.toFixed(2)}, Max: ${maxValue.toFixed(2)}`}
+    >
+      <svg width={computedWidth} height={height} className="border border-gray-200 rounded bg-gray-100">
         <polyline points={points} fill="none" stroke="#3b82f6" strokeWidth="1.5" />
       </svg>
     </div>


### PR DESCRIPTION
## Summary
- compute AreaChart width from a prop or parent element
- remove unused checkerSize state

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842021272d88328abc05bc2a9b03da0